### PR TITLE
fix: Update require statement from `@cypress/registry-js` to `reg…

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -7,7 +7,7 @@ let registry
 
 try {
   // @ts-ignore
-  registry = require('@cypress/registry-js')
+  registry = require('registry-js')
 } catch (err) {
   if (os.platform() === 'win32') {
     debug(
@@ -15,7 +15,7 @@ try {
     )
   } else {
     debug(
-      'Skipping loading @cypress/registry-js because your platform is not win32.'
+      'Skipping loading registry-js because your platform is not win32.'
     )
 
     registry = {


### PR DESCRIPTION
- close #1 

Seems the require statement was left over from older dep we used to use (`@cypress/registry-js`) but should correctly reference `registry.js` from https://github.com/cypress-io/get-windows-proxy/commit/5029dd160548c42e60dba94378ec8e17e0282e57