### PR TITLE
ci(deps): update circleci to cimg/node:22.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,12 @@
-# Javascript Node CircleCI 2.0 configuration file
+# Javascript Node CircleCI 2.1 configuration file
 #
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+# Check https://circleci.com/docs/language-javascript/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
-      # specify the version you desire here
-      - image: circleci/node
+      - image: cimg/node:22.17
 
     working_directory: ~/repo
 
@@ -32,7 +31,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node
+      - image: cimg/node:22.17
     steps:
       - checkout
       - restore_cache:
@@ -43,7 +42,6 @@ jobs:
       - run: ./node_modules/.bin/semantic-release
 
 workflows:
-  version: 2
   test_and_release:
     jobs:
       - build


### PR DESCRIPTION
- closes https://github.com/cypress-io/get-windows-proxy/issues/11
- closes https://github.com/cypress-io/get-windows-proxy/issues/13

## Situation

When the CircleCI configuration [.circleci/config.yml](https://github.com/cypress-io/get-windows-proxy/blob/develop/.circleci/config.yml) is run, it fails with

> error minimatch@10.0.3: The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "17.2.0"
> error Found incompatible module.

## Background

- The workflow uses the deprecated Docker image `circleci/node`
- `circleci/node:latest` is configured for Node.js `17.2.0`
- `circleci/*` images were [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) on Dec 31, 2021
- Node.js `17.x` entered [End-of-Life](https://github.com/nodejs/Release/blob/main/README.md#end-of-life-releases) on Jun 1, 2022
- Cypress `release/15.0.0`, based on [Electron release](https://releases.electronjs.org/) 36, is targeting Node.js `22.15.1`

## Change

Update the CircleCI configuration [.circleci/config.yml](https://github.com/cypress-io/get-windows-proxy/blob/develop/.circleci/config.yml):

- replace Docker image `circleci/node` with the [convenience image cimg/node](https://circleci.com/developer/images/image/cimg/node) using the tag `22.17`
- Update to CircleCI `version: 2.1`, the current version (see https://circleci.com/docs/language-javascript/)