### PR TITLE
chore: migrate to default npmjs registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-registry=http://registry.npmjs.org/
 save-exact=true
 progress=false
 package-lock=false

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "main": "src/",
   "private": false,
   "publishConfig": {
-    "registry": "http://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Situation

[.npmrc](https://github.com/cypress-io/get-windows-proxy/blob/develop/.npmrc) defines

`registry=http://registry.npmjs.org/`

The default [registry](https://docs.npmjs.com/cli/v11/using-npm/config#registry) is `https://registry.npmjs.org/`

Executing `npm install --force` provokes a warning message, showing that the setting has been deprecated since the year 2021:

> npm notice Beginning October 4, 2021, all connections to the npm registry - including for package installation - must use TLS 1.2 or higher. You are currently using plaintext http to connect. Please visit the GitHub blog for more information: https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/

## Change

- Remove `registry=http://registry.npmjs.org/` from [.npmrc](https://github.com/cypress-io/get-windows-proxy/blob/develop/.npmrc) and fallback to use the default `https://registry.npmjs.org/`, in alignment with the main [Cypress repo](https://github.com/cypress-io/cypress/blob/develop/.npmrc)

- Update `publishConfig` in package.json to use https://registry.npmjs.org/ (`https` instead of the disabled `http` protocol)
