### PR TITLE
fix(deps): update registry-js to 1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "debug": "4.1.1"
   },
   "optionalDependencies": {
-    "registry-js": "1.13.0"
+    "registry-js": "1.16.1"
   }
 }


### PR DESCRIPTION
- closes https://github.com/cypress-io/get-windows-proxy/issues/16

## Situation

The currently configured [registry-js@1.13.0](https://github.com/desktop/registry-js/releases/tag/v1.13.0) is not compatible with Visual Studio Community 2022 and results in a build failure of the win32 binary when attempting to use `node-gyp`.

## Change

Update from [registry-js@1.13.0](https://github.com/desktop/registry-js/releases/tag/v1.13.0) to [registry-js@1.16.1](https://github.com/desktop/registry-js/releases/tag/v1.16.1) (current `latest`)

## Verification

In the following environment:

| Component                    | Version                  |
| ---------------------------- | ------------------------ |
| Windows                      | 11, 24H2                 |
| Node.js                      | 22.17.0 LTS              |
| Yarn                         | 1.22.22                  |
| Python                       | 3.13.5                   |
| Visual Studio                | Community 2022 - 17.14.8 |
| Desktop development with C++ |                          |

execute

```shell
yarn install --no-lockfile
```

and confirm that there are no errors, only warnings, and particularly the following step should not show errors:

```text
[4/4] Building fresh packages...
```
