### PR TITLE
chore(deps): update semantic-release to 24.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "mocha": "6.0.2",
     "pre-git": "3.17.1",
     "prettier-eslint-cli": "4.7.1",
-    "semantic-release": "15.13.3",
+    "semantic-release": "24.2.6",
     "simple-commit-message": "4.0.3",
     "sinon": "7.2.5"
   },


### PR DESCRIPTION
- partially resolves issue https://github.com/cypress-io/get-windows-proxy/issues/19

## Situation

The currently configured [semantic-release@15.13.3](https://github.com/semantic-release/semantic-release/releases/tag/v15.13.3), released Jan 10, 2019, causes multiple warnings when installing dependencies with Yarn.

## Assessment

A minimum of `semantic-release` `22.x` is required to remove the multiple deprecation warnings

[semantic-release@24.2.6](https://github.com/semantic-release/semantic-release/releases/tag/v24.2.6) is the current version

## Change

Update from [semantic-release@15.13.3](https://github.com/semantic-release/semantic-release/releases/tag/v15.13.3) to [semantic-release@24.2.6](https://github.com/semantic-release/semantic-release/releases/tag/v24.2.6)