### PR TITLE
fix(deps): update debug to 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "sinon": "7.2.5"
   },
   "dependencies": {
-    "debug": "4.1.1"
+    "debug": "4.4.1"
   },
   "optionalDependencies": {
     "registry-js": "1.13.0"


### PR DESCRIPTION
- partially resolves issue #19

## Situation

The configured version [debug@4.1.1](https://github.com/debug-js/debug/releases/tag/4.1.1), released Dec 22, 2018, has a low severity vulnerability.

## Change

Update from [debug@4.1.1](https://github.com/debug-js/debug/releases/tag/4.1.1) to [debug@4.4.1](https://github.com/debug-js/debug/releases/tag/4.4.1) (current `latest`)