### PR TITLE
chore(deps): migrate eslint to 8.57.1

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,10 @@
 {
+  "plugins": [
+    "@cypress/dev"
+  ],
   "extends": [
-    "plugin:cypress-dev/general",
-    "plugin:cypress-dev/tests"
+    "plugin:@cypress/dev/general",
+    "plugin:@cypress/dev/tests"
   ],
   "rules": {
     "comma-dangle": "off",

--- a/package.json
+++ b/package.json
@@ -42,17 +42,18 @@
     "repositoryUrl": "https://github.com/cypress-io/get-windows-proxy.git"
   },
   "devDependencies": {
+    "@cypress/eslint-plugin-dev": "6.0.0",
     "ban-sensitive-files": "1.9.14",
     "chai": "4.2.0",
     "dependency-check": "3.4.1",
     "deps-ok": "1.4.1",
-    "eslint": "5.14.1",
-    "eslint-plugin-cypress-dev": "2.0.0",
-    "eslint-plugin-mocha": "5.3.0",
+    "eslint": "8.57.1",
+    "eslint-plugin-json-format": "2.0.1",
+    "eslint-plugin-mocha": "10.5.0",
     "git-issues": "1.3.1",
     "license-checker": "25.0.1",
     "mocha": "6.0.2",
-    "prettier-eslint-cli": "4.7.1",
+    "prettier-eslint-cli": "8.0.1",
     "semantic-release": "24.2.6",
     "sinon": "7.2.5"
   },


### PR DESCRIPTION
- closes #18 following on from PR #26
- partially resolves issue #31 

## Situation

`npm install` fails due to ESLint-related dependency issues (see https://github.com/cypress-io/get-windows-proxy/issues/18)

The dependencies used for ESLint are all outdated.  [eslint-plugin-mocha@5.3.0](https://github.com/lo1tuma/eslint-plugin-mocha/releases/tag/5.3.0), released Feb 13, 2019, is not compatible with Node.js 22. `eslint-plugin-mocha@^10` is required.

| Package                                                                              | Version  | Status                                 | Latest   |
| ------------------------------------------------------------------------------------ | -------- | -------------------------------------- | -------- |
| [eslint](https://www.npmjs.com/package/eslint)                                       | `5.14.1` | End-of-life 2019-12-21                 | `9.x`    |
| [eslint-plugin-cypress-dev](https://www.npmjs.com/package/eslint-plugin-cypress-dev) | `2.0.0`  | Deprecated & Archived                  | `5.0.0`  |
| [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha)             | `5.3.0`  | Node.js 22 and flat config unsupported | `11.1.0` |
| [prettier-eslint-cli](https://github.com/prettier/prettier-eslint-cli)               | `4.7.1`  |                                        | `8.0.1`  |

## Change

| Package                                                                              | From     | To Package                                                                             | To Version |
| ------------------------------------------------------------------------------------ | -------- | -------------------------------------------------------------------------------------- | ---------- |
| [eslint](https://www.npmjs.com/package/eslint)                                       | `5.14.1` | same                                                                                   | `8.57.1`   |
| [eslint-plugin-cypress-dev](https://www.npmjs.com/package/eslint-plugin-cypress-dev) | `2.0.0`  | [@cypress/eslint-plugin-dev](https://www.npmjs.com/package/@cypress/eslint-plugin-dev) | `6.0.0`    |
| [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha)             | `5.3.0`  | same                                                                                   | `10.5.0`   |
| -                                                                                    | -        | [eslint-plugin-json-format](https://www.npmjs.com/package/eslint-plugin-json-format)   | `2.0.1`    |
| [prettier-eslint-cli](https://github.com/prettier/prettier-eslint-cli)               | `4.7.1`  | same                                                                                   | `8.0.1`    |

Note: the highest version of ESLint currently supported by [@cypress/eslint-plugin-dev](https://www.npmjs.com/package/@cypress/eslint-plugin-dev) is `eslint^8.0.0`. This version of ESLint reached [end-of-life](https://eslint.org/version-support/) on Oct 10, 2024.