### PR TITLE
chore: remove npm run size pre-push execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
       "pre-push": [
         "npm run unused-deps",
         "npm run license",
-        "npm run ban -- --all",
-        "npm run size"
+        "npm run ban -- --all"
       ],
       "post-commit": [],
       "post-merge": []


### PR DESCRIPTION
- partially resolves issue https://github.com/cypress-io/get-windows-proxy/issues/18

## Situation

The `pre-push` hook, containing `npm run size` fails on Windows and prevents `git push` without using the `--no-verify` option.

## Steps to reproduce

On Windows:

```shell
npm run size
```

## Logs

```text
$ npm run size

> @cypress/get-windows-proxy@0.0.0-development size
> t="$(npm pack .)"; wc -c "${t}"; tar tvf "${t}"; rm "${t}";

't' is not recognized as an internal or external command,
operable program or batch file.
```

## Change

- Remove the command `npm run size` from the `pre-push` hook to allow pushing when contributing to the repo from a Microsoft Windows operating system
- The script `size` is left in place. In can be used on Linux or it could be added to CI running in a Linux Docker image.