### PR TITLE
chore(deps): remove simple-commit-message

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "bugs": "https://github.com/cypress-io/get-windows-proxy/issues",
   "config": {
     "pre-git": {
-      "commit-msg": "simple",
       "pre-commit": [
         "npm prune",
         "npm run deps",
@@ -59,7 +58,6 @@
     "unused-deps": "dependency-check --unused --no-dev ."
   },
   "release": {
-    "analyzeCommits": "simple-commit-message",
     "repositoryUrl": "https://github.com/cypress-io/get-windows-proxy.git"
   },
   "devDependencies": {
@@ -76,7 +74,6 @@
     "pre-git": "3.17.1",
     "prettier-eslint-cli": "4.7.1",
     "semantic-release": "24.2.6",
-    "simple-commit-message": "4.0.3",
     "sinon": "7.2.5"
   },
   "dependencies": {


### PR DESCRIPTION
## Situation

The npm package [simple-commit-message@4.0.3](https://github.com/bahmutov/simple-commit-message/releases/tag/v4.0.3) configured in the repo, was released on Feb 15, 2018, and is outdated.

The latest release of the package [simple-commit-message@4.1.3](https://github.com/bahmutov/simple-commit-message/releases/tag/v4.1.3), released on Jul 4, 2021 is effectively unmaintained and has the following issues:

- Uses non-standard commit message types (see https://github.com/bahmutov/simple-commit-message/blob/master/README.md#valid-commit-messages) `major:` and `minor:`. Does not allow the use of `docs:`, `testing:`, etc. used in other Cypress repos.
- Contains multiple unfixable vulnerabilities:
  > 10 vulnerabilities (1 low, 2 moderate, 4 high, 3 critical)

## Change

In [package.json](https://github.com/cypress-io/get-windows-proxy/blob/develop/package.json), remove:

- npm package [simple-commit-message](https://github.com/bahmutov/simple-commit-message)
- `pre-git` / `"commit-msg": "simple"`
- `semantic-release` configuration `"analyzeCommits": "simple-commit-message"` which then falls back to using the default [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer) which, in turn, uses [Angular's commit-message-guidelines](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md)