### PR TITLE
chore(deps): remove pre-git and simple-commit-message

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,26 +4,6 @@
   "version": "0.0.0-development",
   "author": "Zach Bloomquist <zach@cypress.io>",
   "bugs": "https://github.com/cypress-io/get-windows-proxy/issues",
-  "config": {
-    "pre-git": {
-      "commit-msg": "simple",
-      "pre-commit": [
-        "npm prune",
-        "npm run deps",
-        "npm test",
-        "git add src/*.js",
-        "npm run ban"
-      ],
-      "pre-push": [
-        "npm run unused-deps",
-        "npm run license",
-        "npm run ban -- --all",
-        "npm run size"
-      ],
-      "post-commit": [],
-      "post-merge": []
-    }
-  },
   "files": [
     "src/*.js",
     "!src/*-spec.js"
@@ -59,7 +39,6 @@
     "unused-deps": "dependency-check --unused --no-dev ."
   },
   "release": {
-    "analyzeCommits": "simple-commit-message",
     "repositoryUrl": "https://github.com/cypress-io/get-windows-proxy.git"
   },
   "devDependencies": {
@@ -73,10 +52,8 @@
     "git-issues": "1.3.1",
     "license-checker": "25.0.1",
     "mocha": "6.0.2",
-    "pre-git": "3.17.1",
     "prettier-eslint-cli": "4.7.1",
     "semantic-release": "24.2.6",
-    "simple-commit-message": "4.0.3",
     "sinon": "7.2.5"
   },
   "dependencies": {


### PR DESCRIPTION
partially resolves issues:

- #18
- #31 

## Situation

### pre-git

The npm package [pre-git@3.17.1](https://github.com/bahmutov/pre-git/releases/tag/v3.17.1), configured in the repo, was released on Mar 13, 2018. This was 7 years ago and is the latest release of the package. The package is effectively unmaintained.

- `pre-git` contains multiple unfixable vulnerabilities:
  > 16 vulnerabilities (5 moderate, 7 high, 4 critical)
- The `postinstall` hook of `pre-git` adds a `semantic-release` configuration option, changing the default, if `simple-commit-message` has been uninstalled
  ```json
    "release": {
    "analyzeCommits": "simple-commit-message"
  },
  ```

### simple-commit-message

[simple-commit-message](https://github.com/bahmutov/simple-commit-message) is in the `dependencies` section of [pre-git](https://github.com/bahmutov/pre-git) and therefore the two need to be considered together:

The npm package [simple-commit-message@4.0.3](https://github.com/bahmutov/simple-commit-message/releases/tag/v4.0.3) configured in the repo, was released on Feb 15, 2018 and is outdated.

The latest release of the package [simple-commit-message@4.1.3](https://github.com/bahmutov/simple-commit-message/releases/tag/v4.1.3), released on Jul 4, 2021 is effectively unmaintained and has the following issues:

- Uses non-standard commit message types (see https://github.com/bahmutov/simple-commit-message/blob/master/README.md#valid-commit-messages) `major:` and `minor:`. Does not allow the use of `docs:`, `testing:`, etc. used in other Cypress repos.
- Contains multiple unfixable vulnerabilities:
  > 10 vulnerabilities (1 low, 2 moderate, 4 high, 3 critical)

## Assessment

At this time, where only emergency fixes are being applied to raise compatibility of the repo to Node.js 22 level, `pre-git`, its hooks and `simple-commit-message` are a hindrance, not a help, to these tasks.

`pre-git` manipulation of the `analyzeCommits` configuration of `semantic-release` adds unnecessary complexity to the general update task.

## Change

In [package.json](https://github.com/cypress-io/get-windows-proxy/blob/develop/package.json), remove:

- npm packages [pre-git](https://github.com/bahmutov/pre-git) and [simple-commit-message](https://github.com/bahmutov/simple-commit-message)
- `config` key containing `pre-git`
- `semantic-release` configuration `"analyzeCommits": "simple-commit-message"` which then falls back to using the default [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer) which, in turn, uses [Angular's commit-message-guidelines](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md)

## Follow-up

Optionally look at introducing a mainstream and supported replacement for adding and using git hooks, such as [Husky](https://typicode.github.io/husky/) once other dependencies and configuration details have been successfully updated.

Locally, it may be necessary to remove hooks from `.git/hooks` manually. 
