### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,18 +44,18 @@
   "devDependencies": {
     "@cypress/eslint-plugin-dev": "6.0.0",
     "ban-sensitive-files": "1.9.14",
-    "chai": "4.2.0",
-    "dependency-check": "3.4.1",
+    "chai": "5.2.1",
+    "dependency-check": "4.1.0",
     "deps-ok": "1.4.1",
     "eslint": "8.57.1",
     "eslint-plugin-json-format": "2.0.1",
     "eslint-plugin-mocha": "10.5.0",
     "git-issues": "1.3.1",
     "license-checker": "25.0.1",
-    "mocha": "6.0.2",
+    "mocha": "11.7.1",
     "prettier-eslint-cli": "8.0.1",
     "semantic-release": "24.2.6",
-    "sinon": "7.2.5"
+    "sinon": "21.0.0"
   },
   "dependencies": {
     "debug": "4.4.1"


### PR DESCRIPTION
- partially resolves issue #31 

## Situation

Several `devDependencies` are very outdated

| Dependency                                                                                              | Released    | Comment                     |
| ------------------------------------------------------------------------------------------------------- | ----------- | --------------------------- |
| [chai@4.2.0](https://github.com/chaijs/chai/releases/tag/4.2.0)                                         | 7 years ago |                             |
| [dependency-check@3.4.1](https://github.com/dependency-check-team/dependency-check/releases/tag/v3.4.1) | 6 years ago | deprecated in favor of knip |
| [mocha@6.0.2](https://github.com/mochajs/mocha/releases/tag/v6.0.2)                                     | 6 years ago |                             |
| [sinon@7.2.5](https://github.com/sinonjs/sinon/tree/v7.2.5)                                             | 6 years ago | version is deprecated       |

## Change

Update

| From                                                                                                    | To (`latest`)                                                                                           |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [chai@4.2.0](https://github.com/chaijs/chai/releases/tag/4.2.0)                                         | [chai@5.2.1](https://github.com/chaijs/chai/releases/tag/5.2.1)                                         |
| [dependency-check@3.4.1](https://github.com/dependency-check-team/dependency-check/releases/tag/v3.4.1) | [dependency-check@4.1.0](https://github.com/dependency-check-team/dependency-check/releases/tag/v4.1.0) |
| [mocha@6.0.2](https://github.com/mochajs/mocha/releases/tag/v6.0.2)                                     | [mocha@11.7.1](https://github.com/mochajs/mocha/releases/tag/v11.7.1)                                   |
| [sinon@7.2.5](https://github.com/sinonjs/sinon/tree/v7.2.5)                                             | [sinon@21.0.0](https://github.com/sinonjs/sinon/tree/v21.0.0)                                           |

## Result

The number of deprecation notices and vulnerabilities is reduced. Further PRs acting on `devDependencies` will be necessary to address the remaining issues.