### PR TITLE
chore: normalize package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cypress-io/get-windows-proxy.git"
+    "url": "git+https://github.com/cypress-io/get-windows-proxy.git"
   },
   "scripts": {
     "ban": "ban",


### PR DESCRIPTION
## Situation

[Publishing logs](https://app.circleci.com/pipelines/github/cypress-io/get-windows-proxy/96/workflows/36552732-29fa-4a09-b92b-6397d671d631/jobs/149/parallel-runs/0/steps/0-104) related to publishing the repo to the npm registry show

> npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
> npm warn publish errors corrected:
> npm warn publish "repository.url" was normalized to "git+https://github.com/cypress-io/get-windows-proxy.git"

## Change

Normalize [package.json](https://github.com/cypress-io/get-windows-proxy/blob/develop/package.json) by running `npm pkg fix` as suggested by the npm warning.

This is given a `chore` commit message type, since npm has already corrected `package.json` on the fly, and correcting it at source will not change the published package. It will only prevent the warning from appearing in future when the repo is re-published.
