### PR TITLE
chore(deps): remove some non-essential dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     "url": "git+https://github.com/cypress-io/get-windows-proxy.git"
   },
   "scripts": {
-    "ban": "ban",
-    "deps": "deps-ok && dependency-check --no-dev .",
-    "issues": "git-issues",
+    "deps": "dependency-check --no-dev .",
     "license": "license-checker --production --onlyunknown --csv",
     "lint": "eslint --fix src/*.js",
     "prelint": "npm run pretty",
@@ -43,14 +41,11 @@
   },
   "devDependencies": {
     "@cypress/eslint-plugin-dev": "6.0.0",
-    "ban-sensitive-files": "1.9.14",
     "chai": "5.2.1",
     "dependency-check": "4.1.0",
-    "deps-ok": "1.4.1",
     "eslint": "8.57.1",
     "eslint-plugin-json-format": "2.0.1",
     "eslint-plugin-mocha": "10.5.0",
-    "git-issues": "1.3.1",
     "license-checker": "25.0.1",
     "mocha": "11.7.1",
     "prettier-eslint-cli": "8.0.1",


### PR DESCRIPTION
## Situation

Several `devDependencies` are problematic and unmaintained

| Dependency                                                               | Issue                                                                   |
| ------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [ban-sensitive-files](https://www.npmjs.com/package/ban-sensitive-files) | critical vulnerabilities                                                |
| [deps-ok](https://www.npmjs.com/package/deps-ok)                         | critical vulnerabilities                                                |
| [git-issues](https://www.npmjs.com/package/git-issues)                   | depends on unsupported [request](https://www.npmjs.com/package/request) |

## Change

Remove
- [ban-sensitive-files](https://www.npmjs.com/package/ban-sensitive-files)
- [deps-ok](https://www.npmjs.com/package/deps-ok)
- [git-issues](https://www.npmjs.com/package/git-issues)

## Verification

Execute

```shell
git clean -xfd
npm install
npm audit
```

and confirm `found 0 vulnerabilities` compared to `21 vulnerabilities (1 low, 8 moderate, 3 high, 9 critical)` previously.