### PR TITLE
chore(deps): remove license-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "scripts": {
     "deps": "dependency-check --no-dev .",
-    "license": "license-checker --production --onlyunknown --csv",
     "lint": "eslint --fix",
     "pretest": "npm run lint",
     "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";",
@@ -45,7 +44,6 @@
     "eslint-plugin-jsonc": "2.20.1",
     "eslint-plugin-mocha": "11.1.0",
     "globals": "16.3.0",
-    "license-checker": "25.0.1",
     "mocha": "11.7.1",
     "semantic-release": "24.2.6",
     "sinon": "21.0.0"


### PR DESCRIPTION
- relates to issue https://github.com/cypress-io/get-windows-proxy/issues/34

## Situation

The npm package [license-checker@25.0.1](https://www.npmjs.com/package/license-checker/v/25.0.1), `latest` version, released 7 years ago, and configured in `devDependencies`, reports multiple deprecations. It is effectively no longer supported.

```text
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated debuglog@1.0.1: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated readdir-scoped-modules@1.1.0: This functionality has been moved to @npmcli/fs
npm warn deprecated osenv@0.1.5: This package is no longer supported.
npm warn deprecated read-package-json@2.1.2: This package is no longer supported. Please use @npmcli/package-json instead.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated read-installed@4.0.3: This package is no longer supported.
```

## Change

- Remove [license-checker@25.0.1](https://www.npmjs.com/package/license-checker/v/25.0.1) from `devDependencies` and from `scripts`.

## Verification

```shell
npm install yarn@latest -g
git clean -xfd
yarn --no-lockfile
yarn run lint
yarn test
git status
```

Confirm no errors reported and no file changes made.