### PR TITLE
chore(deps): remove dependency-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,11 @@
     "url": "git+https://github.com/cypress-io/get-windows-proxy.git"
   },
   "scripts": {
-    "deps": "dependency-check --no-dev .",
     "lint": "eslint --fix",
     "pretest": "npm run lint",
     "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";",
     "test": "npm run unit",
-    "unit": "mocha src/*-spec.js",
-    "unused-deps": "dependency-check --unused --no-dev ."
+    "unit": "mocha src/*-spec.js"
   },
   "release": {
     "repositoryUrl": "https://github.com/cypress-io/get-windows-proxy.git"
@@ -39,7 +37,6 @@
   "devDependencies": {
     "@stylistic/eslint-plugin": "5.3.1",
     "chai": "5.2.1",
-    "dependency-check": "4.1.0",
     "eslint": "9.35.0",
     "eslint-plugin-jsonc": "2.20.1",
     "eslint-plugin-mocha": "11.1.0",


### PR DESCRIPTION
- relates to issue #34 

## Situation

- The repo [dependency-check](https://github.com/dependency-check-team/dependency-check) was last published 6 years ago and was archived on Mar 13, 2024. It is unsupported.

- `yarn` reports multiple deprecations from transitive dependencies of [dependency-check](https://github.com/dependency-check-team/dependency-check)

```text
warning dependency-check@4.1.0: dependency-check has been deprecated in favor of the knip module
warning dependency-check > globby > glob@7.2.3: Glob versions prior to v9 are no longer supported
warning dependency-check > read-package-json@2.1.2: This package is no longer supported. Please use @npmcli/package-json instead.
warning dependency-check > read-package-json > glob@7.2.3: Glob versions prior to v9 are no longer supported
warning dependency-check > globby > glob > inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
warning dependency-check > globby > @types/glob > @types/minimatch@6.0.0: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
```

- The deprecation notice for [dependency-check](https://www.npmjs.com/package/dependency-check) displays the information
  > dependency-check has been deprecated in favor of the knip module

## Change

Remove `dependency-check` from `devDependencies` and from `scripts`.

## Verification

```shell
npm install yarn@latest -g
git clean -xfd
yarn --no-lockfile
yarn run lint
yarn test
git status
```

Confirm no errors reported and no file changes made.
