### PR TITLE
chore: use npm credentials context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,5 +46,6 @@ workflows:
     jobs:
       - build
       - release:
+          context: org-npm-credentials
           requires:
             - build


### PR DESCRIPTION
uses new npm context to more easily adhere to token rotation